### PR TITLE
Update to sha256

### DIFF
--- a/fail.rb
+++ b/fail.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Fail < Formula
   homepage 'https://github.com/prezi/fail'
   version "alpha.6"
-  sha1 '57c88b54d9ae7e0ae6258b866d80d5a802ba6cc2'
+  sha256 '19cabea428aab45ffdb76fa965af7dcf345c82c0e698dbb0b1e456ec1980c3f3'
   head 'git@github.com:prezi/fail', :using => :git
   url "https://github.com/prezi/fail/releases/download/#{version}/fail-#{version}.tgz"
 

--- a/spaghetti.rb
+++ b/spaghetti.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Spaghetti < Formula
   homepage 'https://github.com/prezi/spaghetti'
   version "2.1"
-  sha1 "47c8f38f570bd30bc27f383d226728783b641958"
+  sha256 "d58374ddaf3c041ab3aa260d5b74c91aa17e7ddf9e68eeb9eaefca37654e0f41"
   url "https://github.com/prezi/spaghetti/releases/download/#{version}/spaghetti-#{version}.zip"
 
   def install


### PR DESCRIPTION
brew 1.1.0 disabled sha1 support: https://github.com/Homebrew/brew/releases/tag/1.1.0